### PR TITLE
Allow override init to make custom class fixes #19

### DIFF
--- a/Sources/Slider.swift
+++ b/Sources/Slider.swift
@@ -40,7 +40,7 @@ open class Slider : UIControl {
     
     // MARK: - Initialization
     
-    override init(frame: CGRect) {
+    override public init(frame: CGRect) {
         super.init(frame: frame)
         initialize()
     }


### PR DESCRIPTION
Installed through Cocoapod 

```
My podfile:
pod 'fluid-slider'
```
I Could not subClass `Slider` Class

```
class MySliderView: Slider {
    init(frame: CGRect) {
        super.init(frame: frame) // make superview public
    }
}
```

The error is

```
Incorrect argument label in call (have 'frame:', expected 'coder:')
Replace 'frame' with 'coder'
```

Inside `Slider` class 
`init(coder:)` is `public`
In this commit I made `init(frame:)` `public` also

This'll fix issue number 19
**override init to make custom reusable Slider #19**