### PR TITLE
Fix build error on XCode 16.3+

### DIFF
--- a/Sources/Slider.swift
+++ b/Sources/Slider.swift
@@ -20,7 +20,12 @@ private func isAnimationAllowed() -> Bool {
         isUnderHighload = false
     }
     
-    let isSimulator = TARGET_OS_SIMULATOR != 0
+    // Support for XCode 16.3+
+    #if targetEnvironment(simulator)
+        let isSimulator = true
+    #else
+        let isSimulator = false
+    #endif
     
     return !isSimulator && !ProcessInfo.processInfo.isLowPowerModeEnabled && !UIAccessibility.isReduceMotionEnabled && !isUnderHighload
 }


### PR DESCRIPTION
This line is problematic in XCode 16.3 and later. This PR fixes the issue.

```swift
let isSimulator = TARGET_OS_SIMULATOR != 0
```
